### PR TITLE
Minimum FDB version 5.11

### DIFF
--- a/pyfdb/pyfdb.py
+++ b/pyfdb/pyfdb.py
@@ -19,9 +19,9 @@ import os
 from pkg_resources import parse_version
 import findlibs
 
-__version__ = '0.0.1'
+__version__ = '0.0.3'
 
-__fdb_version__ = "5.6.0"
+__fdb_version__ = "5.11.0"
 
 ffi = cffi.FFI()
 


### PR DESCRIPTION
This small fix changes the minimum required FDB version to 5.11.0. 
In fact, without this fix,  due to the API changes, pyfdb would complain if confronted with a 5.10 (or less) FDB binary library, with messages like 
```
function/symbol 'fdb_new_splitkey' not found in library '/usr/local/lib/libfdb5.so': /usr/local/lib/libfdb5.so: undefined symbol: fdb_new_splitkey

Error retrieving attribute fdb_new_splitkey from library
```
but still not raise a proper error.