### PR TITLE
More permissive utf-8 decoding for error strings from the C++ side.

### DIFF
--- a/pyfdb/pyfdb.py
+++ b/pyfdb/pyfdb.py
@@ -92,7 +92,7 @@ class PatchedLib:
             retval = fn(*args, **kwargs)
             if retval != self.__lib.FDB_SUCCESS and retval != self.__lib.FDB_ITERATION_COMPLETE:
                 error_str = "Error in function {}: {}".format(
-                    name, ffi.string(self.__lib.fdb_error_string(retval)).decode()
+                    name, ffi.string(self.__lib.fdb_error_string(retval)).decode("utf-8", "backslashreplace")
                 )
                 raise FDBException(error_str)
             return retval


### PR DESCRIPTION
On playing with this library I was triggering an error in the C++ `fdb` library. The string being returned apparently contained non-utf-8 characters and so was failing to `.decode()`.  This change makes `.decode` more permissive: when it encounters a non-utf-8 sequence it will put the equivalent raw bytes into the output string using `\xFF` type syntax. https://docs.python.org/3/howto/unicode.html#the-string-type

For reference the error I now get is this:
```python
FDBException: Error in function fdb_archive_multiple: Serious Bug: Cannot find a metkit SplitterBuilder for PeekHandle[BufferedHandle[MemoryHandle[size=10392]]] \xff\xffOD - ffff4f44
```