### PR TITLE
Make give pyfdb more pythonic interfaces

### DIFF
--- a/pyfdb/pyfdb.py
+++ b/pyfdb/pyfdb.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 import io
 import os
+from typing import Iterator
 
 import cffi
 import findlibs
@@ -262,13 +263,14 @@ class DataRetriever(io.RawIOBase):
         lib.fdb_datareader_tell(self.__dataread, where)
         return where[0]
 
-    def read(self, count):
+    def read(self, count=-1) -> bytes:
         self.open()
         if isinstance(count, int):
             buf = bytearray(count)
             read = ffi.new("long*")
             lib.fdb_datareader_read(self.__dataread, ffi.from_buffer(buf), count, read)
             return buf[0 : read[0]]
+        return bytearray()
 
     def __enter__(self):
         return self
@@ -298,10 +300,10 @@ class FDB:
     def flush(self):
         lib.fdb_flush(self.ctype)
 
-    def list(self, request=None, duplicates=False, keys=False):
+    def list(self, request=None, duplicates=False, keys=False) -> Iterator[dict]:
         return ListIterator(self, request, duplicates, keys)
 
-    def retrieve(self, request):
+    def retrieve(self, request) -> DataRetriever:
         return DataRetriever(self, request)
 
     @property
@@ -319,7 +321,7 @@ def archive(data):
     fdb.archive(data)
 
 
-def list(request, duplicates=False, keys=False):
+def list(request, duplicates=False, keys=False) -> Iterator[dict]:
     global fdb
     if not fdb:
         fdb = FDB()

--- a/pyfdb/pyfdb.py
+++ b/pyfdb/pyfdb.py
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import io
 import os
 
 import cffi
@@ -214,7 +215,7 @@ class ListIterator:
                 yield el
 
 
-class DataRetriever:
+class DataRetriever(io.RawIOBase):
     __dataread = None
     __opened = False
 

--- a/pyfdb/pyfdb.py
+++ b/pyfdb/pyfdb.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 import io
 import os
-from typing import Iterator
 
 import cffi
 import findlibs
@@ -187,7 +186,7 @@ class ListIterator:
         self.off = ffi.new("size_t*")
         self.len = ffi.new("size_t*")
 
-    def __next__(self):
+    def __next__(self) -> dict:
         err = lib.fdb_listiterator_next(self.__iterator)
 
         if err != 0:
@@ -300,7 +299,7 @@ class FDB:
     def flush(self):
         lib.fdb_flush(self.ctype)
 
-    def list(self, request=None, duplicates=False, keys=False) -> Iterator[dict]:
+    def list(self, request=None, duplicates=False, keys=False):
         return ListIterator(self, request, duplicates, keys)
 
     def retrieve(self, request) -> DataRetriever:
@@ -321,7 +320,7 @@ def archive(data):
     fdb.archive(data)
 
 
-def list(request, duplicates=False, keys=False) -> Iterator[dict]:
+def list(request, duplicates=False, keys=False):
     global fdb
     if not fdb:
         fdb = FDB()

--- a/pyfdb/pyfdb.py
+++ b/pyfdb/pyfdb.py
@@ -245,7 +245,9 @@ class DataRetriever(io.RawIOBase):
         if isinstance(count, int):
             lib.fdb_datareader_skip(self.__dataread, count)
 
-    def seek(self, where):
+    def seek(self, where, whence=io.SEEK_SET):
+        if whence != io.SEEK_SET:
+            raise NotImplementedError(f"SEEK_CUR and SEEK_END are not currently supported on {self.__class__.__name__} objects")
         self.open()
         if isinstance(where, int):
             lib.fdb_datareader_seek(self.__dataread, where)

--- a/tests/test_pyfdb.py
+++ b/tests/test_pyfdb.py
@@ -70,7 +70,7 @@ def test_archival_read():
     request["param"] = "138"
     print("")
     print("direct function, updated dictionary:", request)
-    it = iter(pyfdb.list(request, True, True))
+    it = pyfdb.list(request, True, True)
 
     el = next(it)
     assert el["path"]


### PR DESCRIPTION
This PR fixes two issues to try to make the objects returned by pyfdb behave more like native python objects.

### Issue 1 DataRetriever does not inherit from io.BaseIO

Objects that represent a stream like pattern in python is usually derived from io.BaseIO or a child of that. pyodc, for example, [checks if an object is derived from io.BaseIO](https://github.com/ecmwf/pyodc/blob/7fe9fd77a5c56e81263917f2724f1418492f15e9/pyodc/reader.py#L24C1-L27C41) in order to determine whether it should be treated like a filename and opened or treated like a stream object. 

I change DataRetriever to inherit from io.RawIOBase and also slightly modiy DataRetriever.seek to implement the correct interface. There's a slight issue here in that really DataRetriever.seek should accept a parameter whence  = io.SEEK_CUR or io.SEEK_END but for now I have just put a NotImplementedError in that path.

I have also added a default value for DataRetriever.read(count = -1) because this is required by the type checker and made it return an empty bytearray if count=0. After this the type checker is now happy to let you pass DataRetriever objects anyway a file object would go. 

### Issue 2 ListIterator is not an iterator

The way ListIterator is implemented is a valid pattern for creating iterables in python, however it has the downside that because `__next__` is not implemented you can't call `next(it)` to get just on value from the output of fdb.list

I slightly refactor ListIterator to implement `__next__`.

EDIT: I've now tested this and am happy that it's correct. 