### PR TITLE
Add "packaging" to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(
         "pytest-flakes",
     ],
     test_suite="tests",
-    install_requires=["cffi", "findlibs", "pyeccodes"],
+    install_requires=["cffi", "findlibs", "pyeccodes", "packaging"],
     zip_safe=False,
 )


### PR DESCRIPTION
In my last PR I updated fdb to use the `packaging` package for version parsing. I had not realised that this is not part of the core library anymore. I've added it as a requirement and verified that it can be installed for python versions 3.8 - 3.13