### PR TITLE
Use FDB_HOME in addition to FDB5_HOME to find the library

### DIFF
--- a/pyfdb/pyfdb.py
+++ b/pyfdb/pyfdb.py
@@ -41,7 +41,8 @@ class PatchedLib:
     """
 
     def __init__(self):
-        self.path = findlibs.find("fdb5")
+        # Find the FDB library, respecting both environment variables FDB_HOME and FDB5_HOME
+        self.path = findlibs.find("fdb5", pkg_name="fdb") or findlibs.find("fdb5", pkg_name="fdb5")
 
         if self.path is None:
             raise RuntimeError("FDB5 library not found")


### PR DESCRIPTION
@ChrisspyB pointed out to me that pyfdb looks for an environment variable called "FDB5_HOME" when searching for the fdb library. This is because by default findlibs assumes your binary is called "lib{x}.so" and your environment variable override is called "{x}_HOME". This PR uses the "pkg_name" argument of findlibs to first check FDB_HOME and only if nothing is found then it tries "FDB5_HOME"

The downside of this approach is that if a system version of fdb is found by "findlibs.find("fdb5", pkg_name="fdb")" then it will never check "FDB5_HOME"