### PR TITLE
Only trigger cd when ci is successful

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
       - "**"
 
 jobs:
-  pypi:
+  deploy-to-pypi:
+    name: continuous-delivery-to-pypi
     uses: ecmwf-actions/reusable-workflows/.github/workflows/cd-pypi.yml@v2
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,3 +95,4 @@ jobs:
           failure
           fixed
           success
+


### PR DESCRIPTION
- Push project to pypi only if ci is succeeding

This is now relying on https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run as well as pushed tags.

So the push to pypi is only triggered in case the ci was successful in the first place.