### PR TITLE
WIP: Add fdb_archive in addition to fdb_archive_multiple

### DIFF
--- a/src/pyfdb/pyfdb.py
+++ b/src/pyfdb/pyfdb.py
@@ -335,6 +335,16 @@ class FDB:
         else:
             lib.fdb_archive_multiple(self.ctype, Request(request).ctype, ffi.from_buffer(data), len(data))
 
+    def archive_single(self, data, request) -> None:
+        """Archive data into the FDB5 database
+
+        Args:
+            data (bytes): bytes data to be archived
+            request (dict | None): dictionary representing the request to be associated with the data,
+                if not provided the key will be constructed from the data.
+        """
+        lib.fdb_archive(self.ctype, Key(request).ctype, ffi.from_buffer(data), len(data))
+
     def flush(self) -> None:
         """Flush any archived data to disk"""
         lib.fdb_flush(self.ctype)


### PR DESCRIPTION
I had a need of this because it allows you to inget arbitrary data blobs. `fdb_archive_multiple` on the other hand tries to determine a whole set of keys by parsing the file. If you're working with experimental formats this is very annoying. 