### PR TITLE
Add datareader.size

### DIFF
--- a/src/pyfdb/processed_fdb.h
+++ b/src/pyfdb/processed_fdb.h
@@ -45,6 +45,7 @@ int fdb_datareader_close(fdb_datareader_t* dr);
 int fdb_datareader_tell(fdb_datareader_t* dr, long* pos);
 int fdb_datareader_seek(fdb_datareader_t* dr, long pos);
 int fdb_datareader_skip(fdb_datareader_t* dr, long count);
+int fdb_datareader_size(fdb_datareader_t* dr, long* size);
 int fdb_datareader_read(fdb_datareader_t* dr, void *buf, long count, long* read);
 int fdb_delete_datareader(fdb_datareader_t* dr);
 

--- a/src/pyfdb/pyfdb.py
+++ b/src/pyfdb/pyfdb.py
@@ -267,12 +267,20 @@ class DataRetriever(io.RawIOBase):
         lib.fdb_datareader_tell(self.__dataread, where)
         return where[0]
 
-    def read(self, count=-1) -> bytes:
+    def size(self):
+        size = ffi.new("long*")
+        lib.fdb_datareader_size(self.__dataread, size)
+        return size[0]
+
+    
+    def read(self, size=-1) -> bytes:
         self.open()
-        if isinstance(count, int):
-            buf = bytearray(count)
+        if isinstance(size, int):
+            if (size == -1 ): 
+                size = self.size()
+            buf = bytearray(size)
             read = ffi.new("long*")
-            lib.fdb_datareader_read(self.__dataread, ffi.from_buffer(buf), count, read)
+            lib.fdb_datareader_read(self.__dataread, ffi.from_buffer(buf), size, read)
             return buf[0 : read[0]]
         return bytearray()
 


### PR DESCRIPTION
Depends on PR: https://github.com/ecmwf/fdb/pull/50

Add size to datareader. This allows nice things like:

```python
    dh = fdb1.retrieve(request)
    blob = dh.read() # no argument now reads whole handle.
    fdb2.archive(blob)
    fdb2.flush()
```