### PR TITLE
Feature/fixTox: Fixing findlib for tox

### DIFF
--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -15,5 +15,6 @@ build:
     - ECCODES_SAMPLES_PATH=$ECCODES_DIR/share/eccodes/samples
     - ECCODES_DEFINITION_PATH=$ECCODES_DIR/share/eccodes/definitions
     - FDB5_CONFIG='{"type":"local","engine":"toc","schema":"'"$TMPDIR"'/pyfdb/tests/default_fdb_schema","spaces":[{"handler":"Default","roots":[{"path":"'"$TMPDIR"'/data/fdb"}]}]}'
+    - ECCODES_PYTHON_USE_FINDLIBS=1
   mkdir:
     - data/fdb

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ package = wheel
 wheel_build_env = .pkg
 deps =
     pytest>=6
-pass_env =
-    FDB_HOME
+pass_env = FDB_HOME, DYLD_LIBRARY_PATH, LD_LIBRARY_PATH
 commands =
     pytest {tty:--color=yes} {posargs}


### PR DESCRIPTION
Tox was failing due to a missing env variable. 

I added the needed one to the tox environment and now tox is usable for testing.