### PR TITLE
ci: migrate ecmwf-actions references to ecmwf

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   pypi:
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/cd-pypi.yml@v2
+    uses: ecmwf/reusable-workflows/.github/workflows/cd-pypi.yml@v2
     secrets: inherit

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   label:
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2
+    uses: ecmwf/reusable-workflows/.github/workflows/label-pr.yml@v2

--- a/.github/workflows/notify-new-issue.yml
+++ b/.github/workflows/notify-new-issue.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify new issue
-        uses: ecmwf-actions/notify-teams-issue@v1
+        uses: ecmwf/notify-teams-issue@v1
         with:
           incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}

--- a/.github/workflows/notify-new-pr.yml
+++ b/.github/workflows/notify-new-pr.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify new PR
-        uses: ecmwf-actions/notify-teams-pr@v1
+        uses: ecmwf/notify-teams-pr@v1
         with:
           incoming_webhook: ${{ secrets.MS_TEAMS_INCOMING_WEBHOOK }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -17,7 +17,7 @@ jobs:
   #   It will correctly handle addition of any new and removal of existing Git objects.
   sync:
     name: sync
-    uses: ecmwf-actions/reusable-workflows/.github/workflows/sync.yml@v2
+    uses: ecmwf/reusable-workflows/.github/workflows/sync.yml@v2
     secrets:
       target_repository: mars/pyfdb
       target_username: ClonedDuck


### PR DESCRIPTION
## Summary
The `ecmwf-actions` GitHub organization has been merged into `ecmwf`.
This PR updates workflow `uses:` directives from `ecmwf-actions/` to `ecmwf/`.

No functional changes - the actions are identical, just relocated.

---
*This PR was created automatically.*
